### PR TITLE
fix(legacy decorator support): allows to stack decorators before export

### DIFF
--- a/config/eslint.config.js
+++ b/config/eslint.config.js
@@ -5,4 +5,9 @@ module.exports = {
     rules: {
         'no-console': 'off',
     },
+    parserOptions: {
+        ecmaFeatures: {
+            legacyDecorators: true,
+        },
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/code-style",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "description": "The JavaScript code style for DHIS2.",
     "bin": {
         "code-style": "./code-style",


### PR DESCRIPTION
- bump patch version to 1.4.**2**
- allows us to do
```js
@syntaticSugar
@withRouter
@connect()
export class
```